### PR TITLE
Remove excessive console.log calls

### DIFF
--- a/src/ingestClient/customerDetailsApiClient.ts
+++ b/src/ingestClient/customerDetailsApiClient.ts
@@ -20,8 +20,6 @@ export class CustomerDetailsApiClient {
     }
 
     async post(payload: CustomerDetailsApiPayload) {
-        console.log(new Date(), this.signature, 'calling CustomerDetails API', payload);
-
         const configGet: AxiosRequestConfig = {
             url: '/customer-details-endpoint/?customerId=' + payload.customerId,
             method: 'get',
@@ -35,7 +33,6 @@ export class CustomerDetailsApiClient {
 
         let resultGet = await this.axiosInstance.request(configGet);
         const httpMethod = (Object.keys(resultGet.data).length > 0) ? 'put' : 'post';
-        console.log(new Date(), this.signature, 'http method is:', httpMethod);
 
         const config: AxiosRequestConfig = {
             url: '/customer-details-endpoint',
@@ -51,7 +48,6 @@ export class CustomerDetailsApiClient {
 
         return this.axiosInstance.request(config)
             .then((response) => {
-                console.log(new Date(), this.signature, "response from CustomerDetails API: ", response.status, response.data);
                 if (response.status >= 300) {
                     console.log(`call to CustomerDetails API failed ${response.status}, ${response.data}`);
                     throw new Error(`${Errors.CUSTOMER_DETAILS_API_ERROR} ${response.status}, ${response.data}`);

--- a/src/ingestClient/ingestApiClient.ts
+++ b/src/ingestClient/ingestApiClient.ts
@@ -24,11 +24,9 @@ export class IngestApiClient {
     }
 
     post(payload: Array<MeterMessage>, requestId: string, done?: () => void) {
-        console.log(new Date(), this.signature, 'calling Ingest API with Request ID', requestId);
         return this.axiosInstance
             .post('/ingest-endpoint', payload)
             .then((response) => {
-                console.log(new Date(), this.signature, "response from Ingest API: ", requestId, response.status, response.data);
                 if (response.status >= 300) {
                     console.log(`${this.signature} call to Ingest API failed ${response.status}, ${response.data}`);
                 }
@@ -45,11 +43,9 @@ export class IngestApiClient {
     }
 
     async postSync(payload: Array<MeterMessage>, requestId: string) {
-        console.log(new Date(), this.signature, 'calling Ingest API with Request ID synchronously', requestId);
         try {
             let response = await this.axiosInstance.post('/ingest', payload);
             let data = await response.data;
-            console.log(new Date(), this.signature, 'request completed:', requestId, response.status, data);
             return response;
          } catch(error) {
             console.log(new Date(), this.signature, "error", error);

--- a/src/ingestClient/manualIngestClient.ts
+++ b/src/ingestClient/manualIngestClient.ts
@@ -23,21 +23,17 @@ export class ManualIngestClient implements IngestClient {
     }
 
     ingestMeter(meter: MeterMessage): void {
-        console.log(new Date(), this.signature, 'queuing meter message: ', meter);
         this.queue.push(meter);
     }
 
     async flush() {
         if (this.queue.length < 1) {
-            console.log(new Date(), this.signature, 'no records in the queue to flush');
             return;
         }
 
         let snapshot = this.queue.splice(0, this.queue.length);
-        console.log(new Date(), this.signature, 'body', snapshot);
 
         let requestId = uuidv4();
-        console.log(new Date(), this.signature, 'starting request', requestId);
         return this.apiClient.postSync(snapshot, requestId);
     }
 

--- a/src/usageClient.ts
+++ b/src/usageClient.ts
@@ -31,9 +31,7 @@ export class UsageClient {
      */
     async getUsage(payload: UsageApiPayload): Promise<any[]> {
         try {
-            console.log(new Date(), this.signature, 'calling Usage API', payload);
             let response = await this.axiosInstance.post('/usage', payload);
-            console.log(new Date(), this.signature, 'obtained result from Usage API', response.status);
             return response.data;
         }
         catch (error) {


### PR DESCRIPTION
### Problem

The SDK logs too much, causing log storage costs to be higher than necessary.

### Solution

Remove calls to `console.log` that just log normal behaviors.