### PR TITLE
[MET-1618] Expose option to retry on all clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,3 +205,13 @@ import {
     CustomerProductPlanApiPayload,
 } from "amberflo-metering-typescript";
 ```
+
+### Request Retry
+
+All clients accept a `retry` parameter to enable retrying idempotent requests
+on 5xx or network failures.  This uses the default configuration of
+[axios-retry](https://github.com/softonic/axios-retry).
+
+Further customization of retry logic is possible by manually patching the
+`client.axiosInstance` attribute of a client, as described in the
+[axios-retry](https://github.com/softonic/axios-retry) documentation.

--- a/src/baseClient.ts
+++ b/src/baseClient.ts
@@ -17,10 +17,9 @@ export default class BaseClient {
 
     /**
      * Initialize a new `BaseClient`
-     * @param {string} apiKey
-     * @param {boolean} debug: Whether to issue debug level logs or not
-     * @param {string} name: Name of the client
-     * @param {boolean} retry: Whether to retry the requests or not (see https://github.com/softonic/axios-retry)
+     * `name`: Name of the client for logging purposes.
+     * `debug`: Whether to issue debug level logs or not.
+     * `retry`: Wheter to retry idempotent requests on 5xx or network errors (see https://github.com/softonic/axios-retry)
      */
     constructor(apiKey: string, debug: boolean, name: string, retry = false) {
         this.signature = `[amberflo-metering ${name}]:`;

--- a/src/baseClient.ts
+++ b/src/baseClient.ts
@@ -21,7 +21,7 @@ export default class BaseClient {
      * `debug`: Whether to issue debug level logs or not.
      * `retry`: Wheter to retry idempotent requests on 5xx or network errors (see https://github.com/softonic/axios-retry)
      */
-    constructor(apiKey: string, debug: boolean, name: string, retry = false) {
+    constructor(apiKey: string, debug: boolean, name: string, retry = true) {
         this.signature = `[amberflo-metering ${name}]:`;
         this.apiKey = apiKey;
         this.debug = debug;

--- a/src/customerDetailsClient.ts
+++ b/src/customerDetailsClient.ts
@@ -11,9 +11,10 @@ export class CustomerDetailsClient extends BaseClient {
     /**
      * Initialize a new `CustomerDetailsClient`
      * `debug`: Whether to issue debug level logs or not.
+     * `retry`: Wheter to retry idempotent requests on 5xx or network errors.
      */
-    constructor(apiKey: string, debug = false) {
-        super(apiKey, debug, 'CustomerDetailsClient', true);
+    constructor(apiKey: string, debug = false, retry = true) {
+        super(apiKey, debug, 'CustomerDetailsClient', retry);
     }
 
     /**

--- a/src/customerPortalSessionClient.ts
+++ b/src/customerPortalSessionClient.ts
@@ -12,9 +12,10 @@ export class CustomerPortalSessionClient extends BaseClient {
     /**
      * Initialize a new `CustomerPortalSessionClient`
      * `debug`: Whether to issue debug level logs or not.
+     * `retry`: Wheter to retry idempotent requests on 5xx or network errors.
      */
-    constructor(apiKey: string, debug = false) {
-        super(apiKey, debug, 'CustomerPortalSessionClient');
+    constructor(apiKey: string, debug = false, retry = false) {
+        super(apiKey, debug, 'CustomerPortalSessionClient', retry);
     }
 
     /**

--- a/src/customerPortalSessionClient.ts
+++ b/src/customerPortalSessionClient.ts
@@ -14,7 +14,7 @@ export class CustomerPortalSessionClient extends BaseClient {
      * `debug`: Whether to issue debug level logs or not.
      * `retry`: Wheter to retry idempotent requests on 5xx or network errors.
      */
-    constructor(apiKey: string, debug = false, retry = false) {
+    constructor(apiKey: string, debug = false, retry = true) {
         super(apiKey, debug, 'CustomerPortalSessionClient', retry);
     }
 

--- a/src/customerPrepaidOrderClient.ts
+++ b/src/customerPrepaidOrderClient.ts
@@ -19,7 +19,7 @@ export class CustomerPrepaidOrderClient extends BaseClient {
      * `debug`: Whether to issue debug level logs or not.
      * `retry`: Wheter to retry idempotent requests on 5xx or network errors.
      */
-    constructor(apiKey: string, debug = false, retry = false) {
+    constructor(apiKey: string, debug = false, retry = true) {
         super(apiKey, debug, 'CustomerPrepaidOrderClient', retry);
     }
 

--- a/src/customerPrepaidOrderClient.ts
+++ b/src/customerPrepaidOrderClient.ts
@@ -17,9 +17,10 @@ export class CustomerPrepaidOrderClient extends BaseClient {
     /**
      * Initialize a new `CustomerPrepaidOrderClient`
      * `debug`: Whether to issue debug level logs or not.
+     * `retry`: Wheter to retry idempotent requests on 5xx or network errors.
      */
-    constructor(apiKey: string, debug = false) {
-        super(apiKey, debug, 'CustomerPrepaidOrderClient');
+    constructor(apiKey: string, debug = false, retry = false) {
+        super(apiKey, debug, 'CustomerPrepaidOrderClient', retry);
     }
 
     /**

--- a/src/customerProductInvoiceClient.ts
+++ b/src/customerProductInvoiceClient.ts
@@ -17,9 +17,10 @@ export class CustomerProductInvoiceClient extends BaseClient {
     /**
      * Initialize a new `CustomerProductInvoiceClient`
      * `debug`: Whether to issue debug level logs or not.
+     * `retry`: Wheter to retry idempotent requests on 5xx or network errors.
      */
-    constructor(apiKey: string, debug = false) {
-        super(apiKey, debug, 'UsageClient');
+    constructor(apiKey: string, debug = false, retry = false) {
+        super(apiKey, debug, 'CustomerProductInvoiceClient', retry);
     }
 
     /**

--- a/src/customerProductInvoiceClient.ts
+++ b/src/customerProductInvoiceClient.ts
@@ -19,7 +19,7 @@ export class CustomerProductInvoiceClient extends BaseClient {
      * `debug`: Whether to issue debug level logs or not.
      * `retry`: Wheter to retry idempotent requests on 5xx or network errors.
      */
-    constructor(apiKey: string, debug = false, retry = false) {
+    constructor(apiKey: string, debug = false, retry = true) {
         super(apiKey, debug, 'CustomerProductInvoiceClient', retry);
     }
 

--- a/src/customerProductPlanClient.ts
+++ b/src/customerProductPlanClient.ts
@@ -13,7 +13,7 @@ export class CustomerProductPlanClient extends BaseClient {
      * Initialize a new `CustomerProductPlanClient`
      * `debug`: Whether to issue debug level logs or not.
      */
-    constructor(apiKey: string, debug = false, retry = false) {
+    constructor(apiKey: string, debug = false, retry = true) {
         super(apiKey, debug, 'CustomerProductPlanClient', retry);
     }
 

--- a/src/customerProductPlanClient.ts
+++ b/src/customerProductPlanClient.ts
@@ -13,8 +13,8 @@ export class CustomerProductPlanClient extends BaseClient {
      * Initialize a new `CustomerProductPlanClient`
      * `debug`: Whether to issue debug level logs or not.
      */
-    constructor(apiKey: string, debug = false) {
-        super(apiKey, debug, 'CustomerProductPlanClient');
+    constructor(apiKey: string, debug = false, retry = false) {
+        super(apiKey, debug, 'CustomerProductPlanClient', retry);
     }
 
     /**

--- a/src/usageClient.ts
+++ b/src/usageClient.ts
@@ -9,9 +9,10 @@ export class UsageClient extends BaseClient {
     /**
      * Initialize a new `UsageClient`
      * `debug`: Whether to issue debug level logs or not.
+     * `retry`: Wheter to retry idempotent requests on 5xx or network errors.
      */
-    constructor(apiKey: string, debug = false) {
-        super(apiKey, debug, 'UsageClient');
+    constructor(apiKey: string, debug = false, retry = false) {
+        super(apiKey, debug, 'UsageClient', retry);
     }
 
     /**

--- a/src/usageClient.ts
+++ b/src/usageClient.ts
@@ -11,7 +11,7 @@ export class UsageClient extends BaseClient {
      * `debug`: Whether to issue debug level logs or not.
      * `retry`: Wheter to retry idempotent requests on 5xx or network errors.
      */
-    constructor(apiKey: string, debug = false, retry = false) {
+    constructor(apiKey: string, debug = false, retry = true) {
         super(apiKey, debug, 'UsageClient', retry);
     }
 


### PR DESCRIPTION
#### Problem

- Some API requests frequently fail with 5xx

#### Solution

- Expose option to enable retry for all clients
- Default to `true`

#### Notes

- Retry logic uses the standard configuration of https://github.com/softonic/axios-retry

> By default, it retries if it is a network error or a 5xx error on an idempotent request (GET, HEAD, OPTIONS, PUT or DELETE).