### PR TITLE
Less verbose logging

### DIFF
--- a/src/baseClient.ts
+++ b/src/baseClient.ts
@@ -72,7 +72,7 @@ export default class BaseClient {
         try {
             this.logDebug(action, params);
             const response = await this.axiosInstance.get<TResponse>(path, params ? { params } : undefined);
-            this.logInfo(action, response.status);
+            this.logDebug(action, response.status);
             return response.data;
         }
         catch (error) {
@@ -87,7 +87,7 @@ export default class BaseClient {
         try {
             this.logDebug(action, payload, params);
             const response = await this.axiosInstance.post<TResponse>(path, payload, params ? { params } : undefined);
-            this.logInfo(action, response.status);
+            this.logDebug(action, response.status);
             return response.data;
         }
         catch (error) {
@@ -102,7 +102,7 @@ export default class BaseClient {
         try {
             this.logDebug(action, payload);
             const response = await this.axiosInstance.put<TResponse>(path, payload);
-            this.logInfo(action, response.status);
+            this.logDebug(action, response.status);
             return response.data;
         }
         catch (error) {

--- a/src/ingestClient/autoIngestClient.ts
+++ b/src/ingestClient/autoIngestClient.ts
@@ -30,7 +30,7 @@ export class AutoIngestClient implements IngestClient {
     }
 
     public start(): void {
-        this.apiClient = new IngestApiClient(this.apiKey);
+        this.apiClient = new IngestApiClient(this.apiKey, this.debug);
         console.log(`${this.signature} start client with batch size: ${this.batchSize} frequency in ms ${this.frequencyMillis} debug ${this.debug}`);
         this.timer = setTimeout(this.dequeueTimer.bind(this), this.frequencyMillis);
     }

--- a/src/ingestClient/ingestApiClient.ts
+++ b/src/ingestClient/ingestApiClient.ts
@@ -1,43 +1,24 @@
-import axios, { AxiosInstance } from 'axios';
-import axiosRetry from 'axios-retry';
-import * as Constants from '../model/constants';
+import BaseClient from "../baseClient";
 import { MeterMessage } from '../model/meterMessage';
 
-export class IngestApiClient {
-    axiosInstance: AxiosInstance;
-    signature: string;
+export class IngestApiClient extends BaseClient {
 
-    constructor(apiKey: string) {
-        this.signature = '[amberflo-metering IngestApiClient]:';
-        this.axiosInstance = axios.create({
-            baseURL: Constants.amberfloBaseUrl,
-            headers: {
-                "X-API-KEY": apiKey,
-                "Content-Type": "application/json"
-            },
-            timeout: 30000
-        });
-        axiosRetry(this.axiosInstance, {
-            retries: 3,
-            retryDelay: axiosRetry.exponentialDelay
-        });
+    constructor(apiKey: string, debug = false, retry = true) {
+        super(apiKey, debug, 'IngestApiClient', retry);
     }
 
     post(payload: Array<MeterMessage>, requestId: string, done?: () => void) {
-        // console.log(new Date(), this.signature, 'calling Ingest API with Request ID', requestId);
+        this.logDebug('about to post meters:', requestId);
         return this.axiosInstance
-            .post('/ingest-endpoint', payload)
+            .post('/ingest', payload)
             .then((response) => {
-                console.log(new Date(), this.signature, "response from Ingest API: ", requestId, response.status, response.data);
-                if (response.status >= 300) {
-                    console.log(`${this.signature} call to Ingest API failed ${response.status}, ${response.data}`);
-                }
+                this.logDebug('request completed:', requestId, response.status, response.data);
                 if (done) {
                     done();
                 }
             })
             .catch((error) => {
-                console.log(this.signature, new Date(), `call to Ingest API failed ${error}`);
+                this.logError('request failed:', requestId, error);
                 if (done) {
                     done();
                 }
@@ -45,14 +26,14 @@ export class IngestApiClient {
     }
 
     async postSync(payload: Array<MeterMessage>, requestId: string) {
-        // console.log(new Date(), this.signature, 'calling Ingest API with Request ID synchronously', requestId);
+        this.logDebug('about to post meters:', requestId);
         try {
             const response = await this.axiosInstance.post<string>('/ingest', payload);
             const data = await response.data;
-            console.log(new Date(), this.signature, 'request completed:', requestId, response.status, data);
+            this.logDebug('request completed:', requestId, response.status, data);
             return response;
         } catch(error) {
-            console.log(new Date(), this.signature, "error", error);
+            this.logError('request failed:', requestId, error);
         }
     }
 }

--- a/src/ingestClient/manualIngestClient.ts
+++ b/src/ingestClient/manualIngestClient.ts
@@ -21,7 +21,7 @@ export class ManualIngestClient implements IngestClient {
 
     start(): void {
         console.log(new Date(), this.signature, `start the client with debug ${this.debug} `);
-        this.apiClient = new IngestApiClient(this.apiKey);
+        this.apiClient = new IngestApiClient(this.apiKey, this.debug);
     }
 
     ingestMeter(meter: MeterMessage): void {


### PR DESCRIPTION
#### Issue

- There's too much request result logging

#### What was done

- [x] Turned some `info` level logs into `debug` level
- [x] Made `IngestApiClient` inherit from `BaseClient` and use its logger functions