### PR TITLE
SBT metering interface for internal review

### DIFF
--- a/src/sbt-metering/metering-interface.ts
+++ b/src/sbt-metering/metering-interface.ts
@@ -37,22 +37,22 @@ export interface IMetering {
    * The function to trigger to create a meter.
    * Once created, the meter can be used to track and analyze the specific usage metrics for tenants.
    */
-  createMeter?: IFunction | IFunctionTrigger;
+  createMeterFunction?: IFunction | IFunctionTrigger;
 
   /**
    * The function to trigger to ingest a usage event.
    * Usage events are used to measure and track the usage metrics associated with the meter.
    */
-  ingest: IFunction | IFunctionTrigger;
+  ingestFunction: IFunction | IFunctionTrigger;
 
   /**
    * The function to trigger to get the usage data that has been recorded for a specific meter.
    */
-  getUsage: IFunction | IFunctionTrigger;
+  getUsageFunction: IFunction | IFunctionTrigger;
 
   /**
    * The function to trigger to exclude specific events from being recorded or included in the usage data.
    * Used for canceling events that were incorrectly ingested.
    */
-  cancelUsageEvents?: IFunction | IFunctionTrigger;
+  cancelUsageEventsFunction?: IFunction | IFunctionTrigger;
 }

--- a/src/sbt-metering/metering-interface.ts
+++ b/src/sbt-metering/metering-interface.ts
@@ -1,0 +1,58 @@
+import { IFunction } from 'aws-cdk-lib/aws-lambda';
+import { DetailType } from '../../utils';
+
+/**
+ * Optional interface that allows specifying both
+ * the function to trigger and the event that will trigger it.
+ */
+export interface IFunctionTrigger {
+  /**
+   * The function definition.
+   */
+  readonly handler: IFunction;
+
+  /**
+   * The detail-type that will trigger the handler function.
+   */
+  readonly trigger: DetailType;
+}
+
+/**
+ * Encapsulates the list of properties for an IMetering construct.
+ */
+export interface IMetering {
+  /**
+   * The function to trigger to create a new customer.
+   * (Customer in this context is a tenant.)
+   */
+  createCustomerFunction: IFunction | IFunctionTrigger;
+
+  /**
+   * The function to trigger to delete a customer.
+   * (Customer in this context is a tenant.)
+   */
+  deleteCustomerFunction: IFunction | IFunctionTrigger;
+
+  /**
+   * The function to trigger to create a meter.
+   * Once created, the meter can be used to track and analyze the specific usage metrics for tenants.
+   */
+  createMeter?: IFunction | IFunctionTrigger;
+
+  /**
+   * The function to trigger to ingest a usage event.
+   * Usage events are used to measure and track the usage metrics associated with the meter.
+   */
+  ingest: IFunction | IFunctionTrigger;
+
+  /**
+   * The function to trigger to get the usage data that has been recorded for a specific meter.
+   */
+  getUsage: IFunction | IFunctionTrigger;
+
+  /**
+   * The function to trigger to exclude specific events from being recorded or included in the usage data.
+   * Used for canceling events that were incorrectly ingested.
+   */
+  cancelUsageEvents?: IFunction | IFunctionTrigger;
+}


### PR DESCRIPTION
## Do Not Merge
This PR is for internal review of the metering interface that we will be adding to aws-sbt https://github.com/awslabs/sbt-aws


### Context

Amberflo is partnering with AWS to provide metering component in SBT. We had a discussion with the SBT team regarding the metering interface. We provided them with this interface definition https://docs.google.com/document/d/1SVcr-ETgoNBknTYj0j92i6AbG7wUpTcJyPytmUVV8is/edit

So the plan is following.
1. We add the IMetering interface to the aws-sbt public package.
2. SBT team will make changes to add the wiring for the new IMetering interface.
3. Amberflo will develop and publish the Amberflo IMetering concrete implementation in a separate public repo.


### Goal
So this PR is for the internal review for Step 1 before we publish the PR in the aws-sbt package.

We want to keep this public IMetering interface generic and not very amberflo specific.